### PR TITLE
feat: ConventionalCommit should not close PR

### DIFF
--- a/.github/workflows/conventional-commit-v1.yml
+++ b/.github/workflows/conventional-commit-v1.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Handle Commits Validation
         run: |
           if [[ "$commitIsValid" == "false" ]]; then
-            gh pr close ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --comment "## **❌ Commit(s) Invalid ❌**
+            gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body "## **❌ Commit(s) Invalid ❌**
             All commits should follow [Conventional Commits](https://www.conventionalcommits.org/pt-br/v1.0.0/) standard.
             
             Update your commits messages and push again. 🚀"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The workflow ["_sonar-analysis.v1.yml_"](https://github.com/Peralta-CashFlow/Cas
 
 The workflow ["_conventional-commit-v1.yml_"](https://github.com/Peralta-CashFlow/CashFlow-WorkFlows/blob/main/.github/workflows/conventional-commit-v1.yml) is responsible for scanning a Pull Request commits and verify if all of them are following [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standards.
 
-If all commits are fine you will be able to merge your PR, if not it will automatically close the PR.
+If all commits are fine you will be able to merge your PR, if not it will fail the workflow.
 
 ## Deploy on GitHub Pages - React
 


### PR DESCRIPTION
Adjusting the workflow to only fail when not all commits follow standards so developer can adjust it.