### PR TITLE
fix: adjusting secrets

### DIFF
--- a/.github/workflows/sonar-analysis-v1.yml
+++ b/.github/workflows/sonar-analysis-v1.yml
@@ -7,6 +7,13 @@ on:
         description: 'SonarQube Project Key'
         required: true
         type: string
+    secrets:
+      TOKEN_GITHUB_PACKAGES:
+        description: 'Token used on maven settings'
+        required: true
+      SONAR_TOKEN:
+        description: 'Token used for Sonar analysis'
+        required: true
 
 jobs:
   build:


### PR DESCRIPTION
Github reusable workflows does not have access directly to secrets, it must be passed on caller declaration.